### PR TITLE
Fix ReportManagement to hide blocked users

### DIFF
--- a/src/admin/pages/ReportManagement.jsx
+++ b/src/admin/pages/ReportManagement.jsx
@@ -37,13 +37,15 @@ export default function ReportManagement() {
           count: r.count,
         }));
 
-        const formattedUsers = (usersRes.data.data || []).map((u) => ({
-          id: u.id || u._id,
-          name: u.name,
-          email: u.email,
-          reportCount: u.reportCount,
-          blocked: u.blocked,
-        }));
+        const formattedUsers = (usersRes.data.data || [])
+          .map((u) => ({
+            id: u.id || u._id,
+            name: u.name,
+            email: u.email,
+            reportCount: u.reportCount,
+            blocked: u.blocked,
+          }))
+          .filter((u) => !u.blocked);
 
         setReportedComments(formattedComments);
         setReportedUsers(formattedUsers);
@@ -73,7 +75,7 @@ export default function ReportManagement() {
       await axios.put(`${API_URL}/admin/block-user/${id}`, null, { // /api/admin/block-user/68663d8ae6abd06ebfb328c8
         headers: { Authorization: `Bearer ${localStorage.getItem('accessToken')}` },
       });
-      setReportedUsers(reportedUsers.filter((u) => u.id !== id));
+      setReportedUsers((prev) => prev.filter((u) => u.id !== id));
     } catch (err) {
       console.error('Failed to block user:', err);
     }


### PR DESCRIPTION
## Summary
- filter out already blocked users from the reported users list
- update state after blocking using a functional setter

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686b88b78e188323acd45e81b3270e40